### PR TITLE
Fix controller and hand tracking pose validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ DISCLAIMER: This software is distributed as-is, without any warranties or condit
 
 # Details and instructions on the Wiki: https://github.com/mbucchia/VirtualDesktop-OpenXR/wiki
 
+## Contributors
+
+- Mathias Peter Nordskog | Roughy
+
 ## Donate
 
 Donations are welcome and totally optional. Please use [my GitHub sponsorship page](https://github.com/sponsors/mbucchia) to make one-time or recurring donations!

--- a/virtualdesktop-openxr/hand_tracking.cpp
+++ b/virtualdesktop-openxr/hand_tracking.cpp
@@ -307,7 +307,7 @@ namespace virtualdesktop_openxr {
             bool needHeightAdjustment = true;
             if (m_bodyState && xrHandTracker.useOpticalTracking &&
                 ((xrHandTracker.side == xr::Side::Left && m_cachedBodyState.LeftHandActive) ||
-                 m_cachedBodyState.RightHandActive)) {
+                 (xrHandTracker.side == xr::Side::Right && m_cachedBodyState.RightHandActive))) {
                 joints = xrHandTracker.side == xr::Side::Left ? m_cachedBodyState.LeftHandJointStates
                                                               : m_cachedBodyState.RightHandJointStates;
 

--- a/virtualdesktop-openxr/space.cpp
+++ b/virtualdesktop-openxr/space.cpp
@@ -622,7 +622,9 @@ namespace virtualdesktop_openxr {
                               TLArg(xr::ToString(state.LinearVelocity).c_str(), "LinearVelocity"));
         }
 
-        const bool isTracked = OVR_SUCCESS(result);
+        // Untracked or unavailable controllers return ovrSuccess_DeviceUnavailable = 1002
+        // which is for some reason considered a success.
+        const bool isTracked = OVR_UNQUALIFIED_SUCCESS(result);
         if (isTracked) {
             locationFlags |= (XR_SPACE_LOCATION_ORIENTATION_VALID_BIT | XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT |
                               XR_SPACE_LOCATION_POSITION_VALID_BIT | XR_SPACE_LOCATION_POSITION_TRACKED_BIT);


### PR DESCRIPTION
## What


### Success check
In `OpenXrRuntime::getControllerPose()` the result of calling `ovr_GetDevicePoses()` is checked for success by using `OVR_SUCCESS()`. This success check assumes that any value >=0 is a success.

For some bizarre reason this includes `ovrSuccess_DeviceUnavailable = 1002`, which is pretty much the only non-0 result code `ovr_GetDevicePoses()` will ever return, and happens when:

- Controllers are not being tracked ( e.g. turned off or using hand tracking instead on Quest2 )
- `Track controllers` is disabled in Virtual Desktop
- The calling OpenXR app is running in Headless mode ( which is probably a bug in its own right )

Since the `Success` of the call is used to determine if the controller is being tracked, effectively any call to `ovr_GetDevicePoses()` is considered to be tracked, even when it is not and the pose is zeroed out.

Changed to use `OVR_UNQUALIFIED_SUCCESS()` instead, which only returns true if result is `ovrSuccess`, i.e. `0`.

The other possible success-type return codes listed in `OVR_ErrorCode.h` do not seem relevant, so we can probably safely assume that only `ovrSuccess` should be considered a success for this call.
I can't think of many situation where device-literally-unavailable should be considered a success, so other uses of `OVR_SUCCESS()` should probably also be scrutinized.

### Hand Tracking fallout

Since `OpenXrRuntime::xrLocateHandJointsEXT` falls back to using the controller pose to emulate hand tracking, the above results in it thinking the returned controller pose is valid, and it proceeds to return what it thinks is a valid set of hand tracking joints to the caller.

### RightHandActive check

`OpenXrRuntime::xrLocateHandJointsEXT` uses the cached `BodyTracking::BodyStateV2::LeftHandActive` and `RightHandActive` to determine if hand-tracking is active. Either side should obviously only be considered if it is the same side hand as the current `XrHandTrackerEXT`, but the `RightHandActive` lacks this check, resulting in both hands being considered active if the right hand is active.

Fixed by adding the same comparison used for the left side.

### Thoughts

Controllers emulating hand tracking and hand tracking emulating controllers makes for a bit of a conundrum when you want to take specific actions only when hand-tracking is active, so the controller pose being unavailable in headless mode is a blessing in disguise in my case. Hopefully that issue will remain until `XR_EXT_hand_tracking_data_source` is implemented *nudge nudge wink wink*.

### Environment
In case any of the behavior I am seeing is environment-specific:

- Quest2  63.0.0.323.363.576419413
- Virtual Desktop 1.30.4
- VirtualDesktopXR 1.0.3.0