### PR TITLE
Stub XR_META_body_tracking_calibration

### DIFF
--- a/version.info
+++ b/version.info
@@ -1,3 +1,3 @@
 major=1
 minor=0
-patch=7
+patch=8

--- a/virtualdesktop-openxr/body_tracking.cpp
+++ b/virtualdesktop-openxr/body_tracking.cpp
@@ -35,6 +35,9 @@
 // Implement emulation for XR_HTCX_vive_tracker_interaction using the body tracking data.
 // https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XR_HTCX_vive_tracker_interaction
 
+// Implement Stub for XR_META_body_tracking_calibration to resolve MetaXR SDK crash
+// https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XR_META_body_tracking_calibration
+
 namespace virtualdesktop_openxr {
 
     using namespace virtualdesktop_openxr::log;
@@ -345,6 +348,17 @@ namespace virtualdesktop_openxr {
         xrBodyTracker.maxFidelity = fidelity;
 
         return XR_SUCCESS;
+    }
+
+    // https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#xrSuggestBodyTrackingCalibrationOverrideMETA
+    XrResult OpenXrRuntime::xrSuggestBodyTrackingCalibrationOverrideMETA(XrBodyTrackerFB bodyTracker,
+                                                                         const XrBodyTrackingCalibrationInfoMETA calibrationInfo) {
+        return XR_ERROR_FEATURE_UNSUPPORTED;
+    }
+
+    // https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#xrResetBodyTrackingCalibrationMETA
+    XrResult OpenXrRuntime::xrResetBodyTrackingCalibrationMETA(XrBodyTrackerFB bodyTracker){
+        return XR_ERROR_FEATURE_UNSUPPORTED;
     }
 
     // https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#xrEnumerateViveTrackerPathsHTCX

--- a/virtualdesktop-openxr/framework/dispatch.gen.cpp
+++ b/virtualdesktop-openxr/framework/dispatch.gen.cpp
@@ -2226,6 +2226,9 @@ namespace RUNTIME_NAMESPACE {
 		else if (extensionName == "XR_META_body_tracking_fidelity") {
 			has_XR_META_body_tracking_fidelity = true;
 		}
+		else if (extensionName == "XR_META_body_tracking_calibration") {
+			has_XR_META_body_tracking_calibration = true;
+		}
 		else if (extensionName == "XR_HTCX_vive_tracker_interaction") {
 			has_XR_HTCX_vive_tracker_interaction = true;
 		}

--- a/virtualdesktop-openxr/framework/dispatch.gen.h
+++ b/virtualdesktop-openxr/framework/dispatch.gen.h
@@ -162,6 +162,7 @@ namespace RUNTIME_NAMESPACE {
 		bool has_XR_FB_body_tracking{false};
 		bool has_XR_META_body_tracking_full_body{false};
 		bool has_XR_META_body_tracking_fidelity{false};
+		bool has_XR_META_body_tracking_calibration{false};
 		bool has_XR_HTCX_vive_tracker_interaction{false};
 
 

--- a/virtualdesktop-openxr/framework/dispatch_generator.py
+++ b/virtualdesktop-openxr/framework/dispatch_generator.py
@@ -49,7 +49,7 @@ EXTENSIONS = ['XR_KHR_D3D11_enable', 'XR_KHR_D3D12_enable', 'XR_KHR_vulkan_enabl
               'XR_KHR_win32_convert_performance_counter_time', 'XR_FB_display_refresh_rate', 'XR_EXT_hand_tracking', 'XR_EXT_hand_tracking_data_source',
               'XR_EXT_eye_gaze_interaction', 'XR_EXT_uuid', 'XR_META_headset_id', 'XR_OCULUS_audio_device_guid', 'XR_MND_headless',
               'XR_FB_eye_tracking_social', 'XR_FB_face_tracking', 'XR_FB_face_tracking2', 'XR_FB_hand_tracking_aim',
-              'XR_FB_body_tracking', 'XR_META_body_tracking_full_body', 'XR_META_body_tracking_fidelity', 'XR_HTCX_vive_tracker_interaction']
+              'XR_FB_body_tracking', 'XR_META_body_tracking_full_body', 'XR_META_body_tracking_fidelity', 'XR_META_body_tracking_calibration', 'XR_HTCX_vive_tracker_interaction']
 
 SILENT_ERRORS = {
     'xrSuggestInteractionProfileBindings': ['XR_ERROR_PATH_UNSUPPORTED'],

--- a/virtualdesktop-openxr/meta_body_tracking_calibration.h
+++ b/virtualdesktop-openxr/meta_body_tracking_calibration.h
@@ -1,0 +1,74 @@
+#ifndef META_BODY_TRACKING_CALIBRATION_H_
+#define META_BODY_TRACKING_CALIBRATION_H_ 1
+
+/**********************
+This file is @generated from the OpenXR XML API registry.
+Language    :   C99
+Copyright   :   (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+***********************/
+
+#include <openxr/openxr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifndef XR_META_body_tracking_calibration
+
+#define XR_META_body_tracking_calibration 1
+#define XR_META_body_tracking_calibration_SPEC_VERSION 1
+#define XR_META_BODY_TRACKING_CALIBRATION_EXTENSION_NAME "XR_META_body_tracking_calibration"
+static const XrStructureType XR_TYPE_BODY_TRACKING_CALIBRATION_INFO_META = (XrStructureType) 1000283002;
+static const XrStructureType XR_TYPE_BODY_TRACKING_CALIBRATION_STATUS_META = (XrStructureType) 1000283003;
+static const XrStructureType XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META = (XrStructureType) 1000283004;
+
+typedef enum XrBodyTrackingCalibrationStateMETA {
+    // Valid calibration, pose is safe to use
+    XR_BODY_TRACKING_CALIBRATION_STATE_VALID_META = 1,
+    // Calibration is still running, pose may be incorrect
+    XR_BODY_TRACKING_CALIBRATION_STATE_CALIBRATING_META = 2,
+    // Calibration is invalid, pose is not safe to use
+    XR_BODY_TRACKING_CALIBRATION_STATE_INVALID_META = 3,
+    XR_BODY_TRACKING_CALIBRATION_STATE_MAX_ENUM_META = 0x7FFFFFFF
+} XrBodyTrackingCalibrationStateMETA;
+
+// XrBodyTrackingCalibrationStatusMETA extends XrBodyJointLocationsFB
+typedef struct XrBodyTrackingCalibrationStatusMETA {
+    XrStructureType                       type;
+    void* XR_MAY_ALIAS                    next;
+    XrBodyTrackingCalibrationStateMETA    status;
+} XrBodyTrackingCalibrationStatusMETA;
+
+typedef struct XrBodyTrackingCalibrationInfoMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    float                       bodyHeight;
+} XrBodyTrackingCalibrationInfoMETA;
+
+typedef struct XrSystemPropertiesBodyTrackingCalibrationMETA {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsHeightOverride;
+} XrSystemPropertiesBodyTrackingCalibrationMETA;
+
+typedef XrResult (XRAPI_PTR *PFN_xrSuggestBodyTrackingCalibrationOverrideMETA)(XrBodyTrackerFB bodyTracker, const XrBodyTrackingCalibrationInfoMETA* calibrationInfo);
+typedef XrResult (XRAPI_PTR *PFN_xrResetBodyTrackingCalibrationMETA)(XrBodyTrackerFB bodyTracker);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSuggestBodyTrackingCalibrationOverrideMETA(
+    XrBodyTrackerFB                             bodyTracker,
+    const XrBodyTrackingCalibrationInfoMETA*    calibrationInfo);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrResetBodyTrackingCalibrationMETA(
+    XrBodyTrackerFB                             bodyTracker);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+#endif /* XR_META_body_tracking_calibration */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/virtualdesktop-openxr/pch.h
+++ b/virtualdesktop-openxr/pch.h
@@ -100,6 +100,7 @@ using Microsoft::WRL::ComPtr;
 // Oculus extra headers.
 #include "meta_body_tracking_full_body.h"
 #include "meta_body_tracking_fidelity.h"
+#include "meta_body_tracking_calibration.h"
 
 // OpenXR loader interfaces.
 #include <openxr/openxr_loader_negotiation.h>

--- a/virtualdesktop-openxr/resource.rc
+++ b/virtualdesktop-openxr/resource.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,7,0
- PRODUCTVERSION 1,0,7,0
+ FILEVERSION 1,0,8,0
+ PRODUCTVERSION 1,0,8,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -67,12 +67,12 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "FileVersion", "1.0.7.0"
+            VALUE "FileVersion", "1.0.8.0"
             VALUE "InternalName", "virtualdesktop-openxr.dll"
             VALUE "LegalCopyright", "Copyright (c) 2023-2024 Matthieu Bucchianeri"
             VALUE "OriginalFilename", "virtualdesktop-openxr.dll"
             VALUE "ProductName", "VirtualDesktopXR"
-            VALUE "ProductVersion", "1.0.7.0"
+            VALUE "ProductVersion", "1.0.8.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/virtualdesktop-openxr/runtime.h
+++ b/virtualdesktop-openxr/runtime.h
@@ -287,6 +287,9 @@ namespace virtualdesktop_openxr {
         XrResult xrGetBodySkeletonFB(XrBodyTrackerFB bodyTracker, XrBodySkeletonFB* skeleton) override;
         XrResult xrRequestBodyTrackingFidelityMETA(XrBodyTrackerFB bodyTracker,
                                                    const XrBodyTrackingFidelityMETA fidelity);
+        XrResult xrSuggestBodyTrackingCalibrationOverrideMETA(XrBodyTrackerFB bodyTracker,
+                                                              const XrBodyTrackingCalibrationInfoMETA calibrationInfo);
+        XrResult xrResetBodyTrackingCalibrationMETA(XrBodyTrackerFB bodyTracker);
         XrResult xrEnumerateViveTrackerPathsHTCX(XrInstance instance,
                                                  uint32_t pathCapacityInput,
                                                  uint32_t* pathCountOutput,

--- a/virtualdesktop-openxr/version.h
+++ b/virtualdesktop-openxr/version.h
@@ -1,3 +1,3 @@
 const unsigned int RuntimeVersionMajor = 1;
 const unsigned int RuntimeVersionMinor = 0;
-const unsigned int RuntimeVersionPatch = 7;
+const unsigned int RuntimeVersionPatch = 8;


### PR DESCRIPTION
MetaXR SDK attempts to bind the functions of XR_META_body_tracking_calibration if it sees that XR_META_body_tracking_full_body is present, it does not check whether the runtime supports calibration via XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META which will crash applications where the SDK is in use.

Solution: Stub the methods allowing binding but return XR_ERROR_FEATURE_UNSUPPORTED, hopefully devs will follow better practices and not use the extension methods when it's explicitly marked as unsupported.